### PR TITLE
Add JSGLR2

### DIFF
--- a/source/langdev/meta/lang/sdf3/configuration.rst
+++ b/source/langdev/meta/lang/sdf3/configuration.rst
@@ -63,6 +63,15 @@ This configuration disables the SDF2 generation, and may cause problems when def
 this feature is not supported yet by SDF3. Furthermore, ``dynamic`` can be used instead of ``java``, to enable lazy parse table
 generation, where the parse table is generated while the program is parsed.
 
+Also, an experimental new version of the SGLR parser implementation is available: JSGLR2. It supports parsing, imploding and
+syntax highlighting. Error reporting, recovery and completions are currently not supported. It can be enabled with:
+
+.. code-block:: yaml
+
+   language:
+     sdf:
+       jsglr-version: v2
+
 .. warning:: Whenever changing any of these configurations, clean the project before rebuilding.
 
 .. TODO: write documentation on how to use SDF3 outside of Spoofax

--- a/source/release/note/2.3.0.rst
+++ b/source/release/note/2.3.0.rst
@@ -52,3 +52,8 @@ SDF3
 - Fix: bug in the SDF3 normalizer for groups of priorities outside of a chain.
 - Fix: added support for generating the parse table from a "permissive" grammar
 - Fix: not necessary to specify the parse table as ``sdf-new.tbl`` in the ESV file when using the new parse table generator.
+
+Parser
+~~~~~~
+
+- Added the new (experimental) SGLR parser implementation JSGLR2.


### PR DESCRIPTION
Add JSGLR2 to the 2.3.0 release notes and document how to use it via `metaborg.yml` in the SDF3 configuration docs.