### PR TITLE
Fix issue in example

### DIFF
--- a/source/langdev/meta/lang/nabl2/stratego-api.rst
+++ b/source/langdev/meta/lang/nabl2/stratego-api.rst
@@ -209,7 +209,7 @@ if any errors were encountered, and fail otherwise.
      example-builder:
          (_, _, ast, path, project-path) -> (output-file, result)
        where analysis := <nabl2-get-resource-analysis> $[[project-path]/[path]];
-             <nabl2-analysis-has-errors> analysis
+             <not(nabl2-analysis-has-errors)> analysis
        with output-file := ... ;
             result      := ...
 


### PR DESCRIPTION
IIUC, `nabl2-analysis-has-errors` needs to be negated for the example builder to run only when there are _no_ errors.