### PR TITLE
Document language.sdf.jsglr-version config option

### DIFF
--- a/source/langdev/manual/config.rst
+++ b/source/langdev/manual/config.rst
@@ -324,7 +324,7 @@ The following configuration options are optional and revert to default values wh
                  version: sdf2
 
       .. describe:: sdf2table
-        
+
         Version of sdf2table to use.
 
         - Format: Either ``c``, ``java``, or ``dynamic``.
@@ -336,8 +336,9 @@ The following configuration options are optional and revert to default values wh
                  sdf2table: java
 
       .. describe:: jsglr-version
-        
-        Version of the JGSLR parser to use. The latter three options are experimental extensions of ``v2``.
+
+        Version of the JGSLR parser to use. The latter three options are extensions of ``v2``, which are described
+        `here <../meta/lang/sdf3/configuration.html#jsglr-version>`_.
 
         - Format: Either ``v1``, ``v2``, ``data-dependent``, ``incremental``, or ``layout-sensitive``.
         - Default: ``v1``

--- a/source/langdev/manual/config.rst
+++ b/source/langdev/manual/config.rst
@@ -327,13 +327,25 @@ The following configuration options are optional and revert to default values wh
         
         Version of sdf2table to use.
 
-        - Format: Either ``c`, ``java``, or ``dynamic``.
+        - Format: Either ``c``, ``java``, or ``dynamic``.
         - Default: ``c``
         - Example::
 
              language:
                sdf:
                  sdf2table: java
+
+      .. describe:: jsglr-version
+        
+        Version of the JGSLR parser to use. The latter three options are experimental extensions of ``v2``.
+
+        - Format: Either ``v1``, ``v2``, ``data-dependent``, ``incremental``, or ``layout-sensitive``.
+        - Default: ``v1``
+        - Example::
+
+             language:
+               sdf:
+                 jsglr-version: v2
 
       .. describe:: placeholder
 

--- a/source/langdev/meta/lang/sdf3/configuration.rst
+++ b/source/langdev/meta/lang/sdf3/configuration.rst
@@ -63,6 +63,9 @@ This configuration disables the SDF2 generation, and may cause problems when def
 this feature is not supported yet by SDF3. Furthermore, ``dynamic`` can be used instead of ``java``, to enable lazy parse table
 generation, where the parse table is generated while the program is parsed.
 
+JSGLR version
+=============
+
 An experimental new version of the SGLR parser implementation is available: JSGLR2. It supports parsing, imploding and
 syntax highlighting. Error reporting, recovery and completions are currently not supported. It can be enabled with:
 
@@ -72,23 +75,14 @@ syntax highlighting. Error reporting, recovery and completions are currently not
      sdf:
        jsglr-version: v2
 
-Two additional configurations of JSGLR2 can also be set enabling data-dependent or layout-sensitive parsing.
-Data-dependent SGLR2 solves deep priority conflicts using data-dependent parsing, which does not require duplicating the grammar productions.
-To enable data-dependent resolution of deep priority conflicts, the version of JSGLR2 needs to be set to:
+There are three extensions of JSGLR2 available. To use them, set the ``jsglr-version`` option to one of the following:
 
-.. code-block:: yaml
-
-   language:
-     sdf:
-       jsglr-version: data-dependent
-
-Final, JSGLR2 has been equipped with support for layout-sensitive parsing. This version can be enabled with:
-
-.. code-block:: yaml
-
-   language:
-     sdf:
-       jsglr-version: layout-sensitive
+:``data-dependent``:    Data-dependent JSGLR2 solves deep priority conflicts using data-dependent parsing, which does
+                        not require duplicating the grammar productions.
+:``incremental``:       Incremental JSGLR2 reuses previous parse results to speed up parsing. This extension is
+                        experimental and only available in the development version of Spoofax.
+:``layout-sensitive``:  Layout-sensitive JSGLR2 is documented in the
+                        `reference manual of SDF3 <reference.html#layout-sensitive-parsing>`_.
 
 .. warning:: Whenever changing any of these configurations, clean the project before rebuilding.
 

--- a/source/release/note/2.6.0.rst
+++ b/source/release/note/2.6.0.rst
@@ -9,3 +9,7 @@ See the corresponding :ref:`migration guide <2.6.0-migration-guide>` for migrati
 Changes
 -------
 
+Parser
+~~~~~~
+
+- Added an incremental variant of the JSGLR2 parser.


### PR DESCRIPTION
I've added documentation the `jsglr-version` option. I've immediately added the `incremental` option to the list (which will be added in metaborg/spoofax#42), should it be noted that this option is not yet available in the stable version of Spoofax?