### PR TITLE
Add JSGLR2 variants: recovery and recovery-incremental

### DIFF
--- a/source/langdev/manual/config.rst
+++ b/source/langdev/manual/config.rst
@@ -337,10 +337,11 @@ The following configuration options are optional and revert to default values wh
 
       .. describe:: jsglr-version
 
-        Version of the JGSLR parser to use. The latter three options are extensions of ``v2``, which are described
-        `here <../meta/lang/sdf3/configuration.html#jsglr-version>`_.
+        Version of the JGSLR parser to use. The options listed after ``v2`` are extensions of ``v2``,
+        `which are described here <../meta/lang/sdf3/configuration.html#jsglr-version>`_.
+        Note that some of these extensions are experimental.
 
-        - Format: Either ``v1``, ``v2``, ``data-dependent``, ``incremental``, or ``layout-sensitive``.
+        - Format: Either ``v1``, ``v2``, ``data-dependent``, ``incremental``, ``layout-sensitive``, ``recovery``, or ``recovery-incremental``.
         - Default: ``v1``
         - Example::
 

--- a/source/langdev/meta/lang/sdf3/configuration.rst
+++ b/source/langdev/meta/lang/sdf3/configuration.rst
@@ -75,14 +75,17 @@ syntax highlighting. Error reporting, recovery and completions are currently not
      sdf:
        jsglr-version: v2
 
-There are three extensions of JSGLR2 available. To use them, set the ``jsglr-version`` option to one of the following:
+There are some extensions of JSGLR2 available. To use them, set the ``jsglr-version`` option to one of the following:
 
-:``data-dependent``:    Data-dependent JSGLR2 solves deep priority conflicts using data-dependent parsing, which does
-                        not require duplicating the grammar productions.
-:``incremental``:       Incremental JSGLR2 reuses previous parse results to speed up parsing. This extension is
-                        experimental and only available in the development version of Spoofax.
-:``layout-sensitive``:  Layout-sensitive JSGLR2 is documented in the
-                        `reference manual of SDF3 <reference.html#layout-sensitive-parsing>`_.
+:``data-dependent``:       Data-dependent JSGLR2 solves deep priority conflicts using data-dependent parsing, which does
+                           not require duplicating the grammar productions.
+:``incremental``:          Incremental JSGLR2 reuses previous parse results to speed up parsing.
+:``layout-sensitive``:     Layout-sensitive JSGLR2 is documented in the
+                           `reference manual of SDF3 <reference.html#layout-sensitive-parsing>`_.
+:``recovery``:             JSGLR2 with recovery tries to recover from parse errors. This extension is experimental and
+                           only available in the development version of Spoofax.
+:``recovery-incremental``: Incremental JSGLR2 with recovery. This extension is experimental and only available in the
+                           development version of Spoofax.
 
 .. warning:: Whenever changing any of these configurations, clean the project before rebuilding.
 

--- a/source/release/note/2.6.0.rst
+++ b/source/release/note/2.6.0.rst
@@ -9,15 +9,20 @@ See the corresponding :ref:`migration guide <2.6.0-migration-guide>` for migrati
 Changes
 -------
 
+Parser
+~~~~~~
+
+Added two experimental variants to the JSGLR2 parser: ``recovery`` and ``recovery-incremental``.
+
 FlowSpec
 ~~~~~~~~
 
-Bugfix: Names with namespaces were broken in an earlier version during performance optimization. The error would like: ``java.lang.AssertionError: Unrecognised Namespace: Namespace("Var")``. 
+Bugfix: Names with namespaces were broken in an earlier version during performance optimization. The error would like: ``java.lang.AssertionError: Unrecognised Namespace: Namespace("Var")``.
 
 Stratego
 ~~~~~~~~
 
-Stratego separate compilation is now switched to the new system. It no longer has any limitations that were previously mentioned. Do note that separate compilation will give the same stricter error messages that the editor does: You need to import anything you use, you cannot use something that another module imports that imports your module. 
+Stratego separate compilation is now switched to the new system. It no longer has any limitations that were previously mentioned. Do note that separate compilation will give the same stricter error messages that the editor does: You need to import anything you use, you cannot use something that another module imports that imports your module.
 
 Overall
 ~~~~~~~


### PR DESCRIPTION
I've added documentation for the `recovery` and `recovery-incremental` options for `jsglr-version`, which have recently been merged to master.