### PR TITLE
Document Unicode support

### DIFF
--- a/source/langdev/meta/lang/sdf3/configuration.rst
+++ b/source/langdev/meta/lang/sdf3/configuration.rst
@@ -60,7 +60,9 @@ a new (and experimental) parse table generator can be selected by writing:
        sdf2table: java
 
 This configuration disables the SDF2 generation, and may cause problems when defining grammars to use concrete syntax, since
-this feature is not supported yet by SDF3. Furthermore, ``dynamic`` can be used instead of ``java``, to enable lazy parse table
+this feature is not supported yet by SDF3.
+However, the ``java`` parse table generator supports Unicode, whereas SDF2 generation does not.
+Furthermore, ``dynamic`` can be used instead of ``java``, to enable lazy parse table
 generation, where the parse table is generated while the program is parsed.
 
 JSGLR version

--- a/source/langdev/meta/lang/sdf3/reference.rst
+++ b/source/langdev/meta/lang/sdf3/reference.rst
@@ -69,12 +69,19 @@ performing a normalization step.
 of special characters. One should use ``\c`` whenever ``c`` is not a digit or a letter
 in a character class.
 
+Arbitrary Unicode code points can be included in a character class by writing an escaped integer,
+which is particularly useful for representing characters outside the printable ASCII range.
+The integer can be a binary, octal, decimal, or hexadecimal number, for example:
+``\0b101010``, ``\052``, ``\42``, and ``\0x2A`` all represent the code point 42,
+or the ``'*'`` character.
+
 Additionally, special ASCII characters are represented by:
 
-- ``\n`` : newline character
-- ``\r`` : carriage return
 - ``\t`` : horizontal tabulation
-- ``\x`` : a non-printable character with decimal code x
+- ``\n`` : newline character
+- ``\v`` : vertical tabulation
+- ``\f`` : form feed
+- ``\r`` : carriage return
 
 **Character Class Operators**: SDF3 provides the following operators for character
 classes:

--- a/source/release/note/2.6.0.rst
+++ b/source/release/note/2.6.0.rst
@@ -12,7 +12,8 @@ Changes
 Parser
 ~~~~~~
 
-Added two experimental variants to the JSGLR2 parser: ``recovery`` and ``recovery-incremental``.
+- Added two experimental variants to the JSGLR2 parser: ``recovery`` and ``recovery-incremental``.
+- Added Unicode support to the JSGLR1 and JSGLR2 parsers. The meta-languages themselves do not support Unicode yet, because they are bootstrapped with and old version of SDF3. However, other languages built with Spoofax can use Unicode.
 
 FlowSpec
 ~~~~~~~~


### PR DESCRIPTION
Closes #28.
Depends on metaborg/jsglr#72 and metaborg/sdf#38.