### PR TITLE
Slightly clarify the doc for `jsglr-version`

### DIFF
--- a/source/langdev/meta/lang/sdf3/configuration.rst
+++ b/source/langdev/meta/lang/sdf3/configuration.rst
@@ -77,17 +77,16 @@ syntax highlighting. Error reporting, recovery and completions are currently not
      sdf:
        jsglr-version: v2
 
-There are some extensions of JSGLR2 available. To use them, set the ``jsglr-version`` option to one of the following:
+There are some extensions of JSGLR2 available. To use them, change the ``jsglr-version`` by replacing ``v2`` with
+one of the following:
 
 :``data-dependent``:       Data-dependent JSGLR2 solves deep priority conflicts using data-dependent parsing, which does
                            not require duplicating the grammar productions.
 :``incremental``:          Incremental JSGLR2 reuses previous parse results to speed up parsing.
 :``layout-sensitive``:     Layout-sensitive JSGLR2 is documented in the
                            `reference manual of SDF3 <reference.html#layout-sensitive-parsing>`_.
-:``recovery``:             JSGLR2 with recovery tries to recover from parse errors. This extension is experimental and
-                           only available in the development version of Spoofax.
-:``recovery-incremental``: Incremental JSGLR2 with recovery. This extension is experimental and only available in the
-                           development version of Spoofax.
+:``recovery``:             JSGLR2 with recovery tries to recover from parse errors. This extension is experimental.
+:``recovery-incremental``: Incremental JSGLR2 with recovery. This extension is experimental.
 
 JSGLR2 logging
 ==============


### PR DESCRIPTION
Thanks to @cmpsb for the suggestion :smile:

I also removed the part about `recovery` and `recovery-incremental` only being available in the development version of Spoofax, since they're available since 2.5.8 (though they're still experimental).