### PR TITLE
Statix remove optional requirement, add constructor requirement

### DIFF
--- a/source/langdev/meta/lang/statix/signature-generator.rst
+++ b/source/langdev/meta/lang/statix/signature-generator.rst
@@ -30,6 +30,7 @@ For the generator to work correctly, your SDF3 must be well formed. In particula
 * not declare sorts that are not used in any rules
 * not use any implicitly declared sorts
 * not use complex injections, such as :sdf3:`Pair = Expr Expr`
+* constructors must start with an upper-case letter
 * not use ``sdf2table: c``
 
 The generator generates strategies and signatures for each explicit declaration

--- a/source/langdev/meta/lang/statix/signature-generator.rst
+++ b/source/langdev/meta/lang/statix/signature-generator.rst
@@ -30,7 +30,6 @@ For the generator to work correctly, your SDF3 must be well formed. In particula
 * not declare sorts that are not used in any rules
 * not use any implicitly declared sorts
 * not use complex injections, such as :sdf3:`Pair = Expr Expr`
-* not use optional terms, such as :sdf3:`Decl.VarDecl = ID Type?`
 * not use ``sdf2table: c``
 
 The generator generates strategies and signatures for each explicit declaration


### PR DESCRIPTION
To prevent others taking days finding the issue that signature files are incorrect(syntax error, not expected here:<first item>).
The requirement for no optionals is no more(at least it compiles), but constructors must start with an upper-case letter.